### PR TITLE
Fix trn1 nodegroups so they use the preferred subnet/AZ

### DIFF
--- a/ai-ml/trainium-inferentia/eks.tf
+++ b/ai-ml/trainium-inferentia/eks.tf
@@ -133,11 +133,11 @@ module "eks" {
     trn1-32xl-ng1 = {
       name        = "trn1-32xl-ng1"
       description = "Tran1 32xlarge node group for hosting ML workloads"
-      # The code filters the private subnets based on their CIDR blocks and selects the subnet ID if the CIDR block starts with "100." Otherwise, it assigns a null value.
-      # The element(compact([...]), 0) expression ensures that only the first non-null value is included in the resulting list of subnet IDs.
-      subnet_ids = [element(compact([for subnet_id, cidr_block in zipmap(module.vpc.private_subnets, module.vpc.private_subnets_cidr_blocks) :
-        substr(cidr_block, 0, 4) == "100." ? subnet_id : null]), 0)]
-
+      # All trn1 instances should be launched into the same subnet in the preferred trn1 AZ
+      # The preferred AZ is the first AZ listed in the AZ id <-> region mapping in main.tf.
+      # We use index 2 to select the subnet in AZ1 with the 100.x CIDR:
+      #   module.vpc.private_subnets = [AZ1_10.x, AZ2_10.x, AZ1_100.x, AZ2_100.x]
+      subnet_ids = [module.vpc.private_subnets[2]]
       # aws ssm get-parameters --names /aws/service/eks/optimized-ami/1.27/amazon-linux-2-gpu/recommended/image_id --region us-west-2
       # ami_id   = "ami-0e0deb7ae582f6fe9" # Use this to pass custom AMI ID and ignore ami_type
       ami_type       = "AL2_x86_64_GPU" # Contains Neuron driver
@@ -278,15 +278,14 @@ module "eks" {
     trn1n-32xl-ng = {
       name        = "trn1n-32xl-ng"
       description = "trn1n 32xlarge node group for hosting ML workloads"
-      # The code filters the private subnets based on their CIDR blocks and selects the subnet ID if the CIDR block starts with "100." Otherwise, it assigns a null value.
-      # The element(compact([...]), 0) expression ensures that only the first non-null value is included in the resulting list of subnet IDs.
-      subnet_ids = [element(compact([for subnet_id, cidr_block in zipmap(module.vpc.private_subnets, module.vpc.private_subnets_cidr_blocks) :
-        substr(cidr_block, 0, 4) == "100." ? subnet_id : null]), 0)
-      ]
-
+      # All trn1 instances should be launched into the same subnet in the preferred trn1 AZ
+      # The preferred AZ is the first AZ listed in the AZ id <-> region mapping in main.tf.
+      # We use index 2 to select the subnet in AZ1 with the 100.x CIDR:
+      #   module.vpc.private_subnets = [AZ1_10.x, AZ2_10.x, AZ1_100.x, AZ2_100.x]
+      subnet_ids = [module.vpc.private_subnets[2]]
       # aws ssm get-parameters --names /aws/service/eks/optimized-ami/1.27/amazon-linux-2-gpu/recommended/image_id --region us-west-2
       # ami_id   = "ami-0e0deb7ae582f6fe9" # Use this to pass custom AMI ID and ignore ami_type
-      ami_type       = "AL2_x86_64_GPU"
+      ami_type       = "AL2_x86_64_GPU" # Contains Neuron driver
       instance_types = ["trn1n.32xlarge"]
 
       pre_bootstrap_user_data = <<-EOT

--- a/ai-ml/trainium-inferentia/main.tf
+++ b/ai-ml/trainium-inferentia/main.tf
@@ -41,9 +41,15 @@ data "aws_ecrpublic_authorization_token" "token" {
 locals {
   name   = var.name
   region = var.region
-  # Training and Inference instances are available in the following AZs us-east-1 and us-west-2
-  # You can find the list of supported AZs here: https://aws.amazon.com/ec2/instance-types/trn1/
-  azs = ["${local.region}c", "${local.region}d"]
+  # Trn1 and Inf2 instances are available in specific AZs in us-east-1,
+  #  us-east-2, and us-west-2. For Trn1, the first AZ id (below) should
+  #  be used.
+  az_mapping = {
+    "us-west-2" = ["usw2-az4", "usw2-az1"],
+    "us-east-1" = ["use1-az6", "use1-az5"],
+    "us-east-2" = ["use2-az3", "use2-az1"]
+  }
+  azs = local.az_mapping[var.region]
   tags = {
     Blueprint  = local.name
     GithubRepo = "github.com/awslabs/data-on-eks"


### PR DESCRIPTION
### What does this PR do?

Trn1 instances are available in several regions, but not available in all AZs. If the trn1 nodegroups are created using the wrong AZs, nodegroup creation will fail.

This PR adds the trn1 region <-> AZ mapping, and updates the trn1/trn1n nodegroup templates to use the preferred AZ/subnet.
